### PR TITLE
Fix icons for add and remove tree node & add a typing

### DIFF
--- a/src/browser/tree-widget.tsx
+++ b/src/browser/tree-widget.tsx
@@ -169,7 +169,7 @@ export class JsonFormsTreeWidget extends TreeWidget {
     };
   }
 
-  public async setData(data: any) {
+  public async setData(data: TreeEditor.TreeData) {
     this.data = data;
     await this.refreshModelChildren();
   }

--- a/src/browser/tree-widget.tsx
+++ b/src/browser/tree-widget.tsx
@@ -118,14 +118,14 @@ export class JsonFormsTreeWidget extends TreeWidget {
         <div className='node-buttons'>
           {addPlus ? (
             <div
-              className='node-button far fa-plus-square'
+              className='node-button fa fa-plus-square'
               onClick={this.createAddHandler(node)}
             />
           ) : (
               ''
             )}
           <div
-            className='node-button far fa-minus-square'
+            className='node-button fa fa-minus-square'
             onClickCapture={this.createRemoveHandler(node)}
           />
         </div>


### PR DESCRIPTION
* Font Awesome (FA) Regular icons (FAR) are not part of the FA icons used by Theia. Therefore, use standard FA icons that are present.
* Add typing for tree widget's `setData` method.