### PR TITLE
Resource tree editor; no root node removal; version update

### DIFF
--- a/DOCUMENTATION.MD
+++ b/DOCUMENTATION.MD
@@ -16,8 +16,14 @@ Furthermore, you need to implement `handleFormUpdate`. This is called whenever t
 `save` needs to be overridden if the tree editor should react to the common save command (e.g. if the user presses Ctrl+S in Theia).
 By default nothing is done when save is called.
 
-If you want to implement an editor which uses a ressource which is loaded from a uri,
-you should consider extending [NavigatableTreeEditorWidget](src/browser/navigatable-tree-editor-widget.ts).
+If you want to implement an editor which uses a resource which is loaded from a uri,
+you should consider extending [ResourceTreeEditorWidget](src/browser/resource/resource-tree-editor-widget.ts).
+This already provides basic implementations for load, save and dirty marker handling, as well as
+adding and removing nodes. This is a good starting point for editors that "simply"
+show files from the theia workspace and don't need custom file retrieval.
+
+In case you have a resource given as a URI but need custom implementations for loading and saving
+the data, you should consider extending [NavigatableTreeEditorWidget](src/browser/navigatable-tree-editor-widget.ts).
 
 ## Theia Services
 To properly show labels and icons for the tree nodes in your editor,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "theia-tree-editor",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "license": "(EPL-2.0 OR MIT)",
   "author": {
     "name": "EclipseSource"

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -16,3 +16,4 @@ export * from './tree-widget';
 export * from './util';
 
 export * from './navigatable-tree-editor-widget';
+export * from './resource/resource-tree-editor-widget';

--- a/src/browser/navigatable-tree-editor-widget.ts
+++ b/src/browser/navigatable-tree-editor-widget.ts
@@ -9,7 +9,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR MIT
  ********************************************************************************/
 import { ILogger } from '@theia/core';
-import { Navigatable } from '@theia/core/lib/browser';
+import { Navigatable, Title, Widget } from '@theia/core/lib/browser';
 import URI from '@theia/core/lib/common/uri';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
 
@@ -56,4 +56,9 @@ export abstract class NavigatableTreeEditorWidget extends JsonFormsTreeEditorWid
         return this.options.uri && this.options.uri.withPath(resourceUri.path);
     }
 
+    protected configureTitle(title: Title<Widget>): void {
+        title.label = this.options.uri.path.base;
+        title.caption = this.options.uri.toString();
+        title.closable = true;
+    }
 }

--- a/src/browser/resource/resource-tree-editor-widget.ts
+++ b/src/browser/resource/resource-tree-editor-widget.ts
@@ -1,0 +1,129 @@
+/********************************************************************************
+ * Copyright (c) 2019-2020 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+import { DefaultResourceProvider, Resource } from '@theia/core/lib/common';
+import { ILogger } from '@theia/core/lib/common';
+import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
+import { postConstruct } from 'inversify';
+import { AddCommandProperty, JsonFormsTreeWidget } from '../tree-widget';
+import { TreeEditor } from '../interfaces';
+import {
+  NavigatableTreeEditorWidget,
+  NavigatableTreeEditorOptions,
+} from '../navigatable-tree-editor-widget';
+import { JSONFormsWidget } from '../json-forms-widget';
+
+export abstract class ResourceTreeEditorWidget extends NavigatableTreeEditorWidget {
+  protected resource: Resource;
+  protected data: any;
+
+  constructor(
+    protected readonly treeWidget: JsonFormsTreeWidget,
+    protected readonly formWidget: JSONFormsWidget,
+    protected readonly workspaceService: WorkspaceService,
+    protected readonly logger: ILogger,
+    readonly widget_id: string,
+    protected readonly options: NavigatableTreeEditorOptions,
+    protected readonly provider: DefaultResourceProvider,
+    protected readonly nodeFactory: TreeEditor.NodeFactory,
+  ) {
+    super(
+      treeWidget,
+      formWidget,
+      workspaceService,
+      logger,
+      widget_id,
+      options
+    );
+  }
+
+  @postConstruct()
+  protected init(): void {
+    super.init();
+    const uri = this.options.uri;
+    this.provider.get(uri).then(
+      resource => {
+        this.resource = resource;
+        this.load();
+      },
+      _ => console.error(`Could not create ressource for uri ${uri}`)
+    );
+  }
+
+  /**
+   * @return the property that contains data objects' type identifier.
+   */
+  protected abstract getTypeProperty(): string;
+
+  public save(): void {
+    const content = JSON.stringify(this.data);
+    this.resource.saveContents(content).then(
+      _ => this.setDirty(false),
+      error => console.error(`Ressource ${this.uri} could not be saved.`, error)
+    );
+  }
+
+  protected async load(): Promise<void> {
+    let content = undefined;
+    let error = false;
+    try {
+      content = await this.resource.readContents();
+    } catch (e) {
+      console.error(`Loading ${this.resource.uri} failed.`, e);
+      error = true;
+    }
+
+    const json = JSON.parse(content);
+    this.data = json;
+    const treeData: TreeEditor.TreeData = {
+      error,
+      data: json,
+    };
+    this.treeWidget.setData(treeData);
+  }
+
+  protected deleteNode(node: Readonly<TreeEditor.Node>): void {
+    if (node.parent && TreeEditor.Node.is(node.parent)) {
+      const propertyData = node.parent.jsonforms.data[node.jsonforms.property];
+      if (Array.isArray(propertyData)) {
+        propertyData.splice(Number(node.jsonforms.index), 1);
+      } else if (propertyData !== null && typeof propertyData === 'object') {
+        propertyData[node.jsonforms.index] = undefined;
+      } else {
+        this.logger.error(`Could not delete node's data from its parent's property ${node.jsonforms.property}. Property data:`, propertyData);
+        return;
+      }
+
+      // Data was changed in place but need to trigger tree updates.
+      this.treeWidget.updateDataForSubtree(node.parent, node.parent.jsonforms.data);
+      this.setDirty(true);
+    }
+  }
+
+  protected addNode({ node, type, property }: AddCommandProperty): void {
+    // Create an empty object that only contains its type identifier
+    const newData: { [k: string]: any } = {};
+    newData[this.getTypeProperty()] = type;
+
+    // TODO handle children not being stored in an array
+
+    if (!node.jsonforms.data[property]) {
+      node.jsonforms.data[property] = [];
+    }
+    node.jsonforms.data[property].push(newData);
+    this.treeWidget.updateDataForSubtree(node, node.jsonforms.data);
+    this.setDirty(true);
+  }
+
+  protected handleFormUpdate(data: any, node: TreeEditor.Node) {
+    this.treeWidget.updateDataForSubtree(node, data);
+    this.setDirty(true);
+  }
+}

--- a/src/browser/tree-editor-widget.tsx
+++ b/src/browser/tree-editor-widget.tsx
@@ -107,6 +107,18 @@ export abstract class JsonFormsTreeEditorWidget extends BaseWidget
   }
 
   /**
+   * Sets the dirty state of this editor and notify listeners subscribed to the dirty state.
+   *
+   * @param dirty true if the editor is dirty
+   */
+  protected setDirty(dirty: boolean) {
+    if (this.dirty !== dirty) {
+      this.dirty = dirty;
+      this.onDirtyChangedEmitter.fire();
+    }
+  }
+
+  /**
    * Delete the given node including its associated data from the tree.
    *
    * @param node The tree node to delete

--- a/src/browser/tree-widget.tsx
+++ b/src/browser/tree-widget.tsx
@@ -20,8 +20,11 @@ import { v4 } from 'uuid';
 import { TreeEditor } from './interfaces';
 
 export interface AddCommandProperty {
+  /** The node to add a new child to. */
   node: TreeEditor.Node,
+  /** The property to add a new child to. */
   property: string,
+  /** The type identifier of the new child to create. */
   type: string
 }
 
@@ -254,7 +257,7 @@ export class JsonFormsTreeWidget extends TreeWidget {
   /**
    * Updates the data of the given node with the new data. Refreshes the tree if necessary.
    * Note that this method will only work properly if only data relevant for this node was changed.
-   * If data of the subtree was changed too please call updateDataForSubtree instead.
+   * If data of the subtree was changed, too, please call updateDataForSubtree instead.
    */
   public updateDataForNode(node: TreeEditor.Node, data: any) {
     const oldName = this.labelProvider.getName(node);

--- a/src/browser/tree-widget.tsx
+++ b/src/browser/tree-widget.tsx
@@ -115,6 +115,9 @@ export class JsonFormsTreeWidget extends TreeWidget {
     }
 
     const addPlus = this.nodeFactory.hasCreatableChildren(node);
+    // Do not render remove button for root nodes. Root nodes have depth 0.
+    const addRemoveButton = props.depth > 0;
+
     return (
       <React.Fragment>
         {deco}
@@ -127,10 +130,14 @@ export class JsonFormsTreeWidget extends TreeWidget {
           ) : (
               ''
             )}
-          <div
-            className='node-button fa fa-minus-square'
-            onClickCapture={this.createRemoveHandler(node)}
-          />
+          {addRemoveButton ? (
+            <div
+              className='node-button fa fa-minus-square'
+              onClickCapture={this.createRemoveHandler(node)}
+            />
+          ) : (
+              ''
+          )}
         </div>
       </React.Fragment>
     );


### PR DESCRIPTION
Add a new ResourceTreeEditorWidget that extends the NavigatableTreeEditorWidget. The new widget provides the following features:
* automatic data loading from a resource given by URI
* handling for dirty state, save
* handling for node addition and removal
---
No longer render the remove button for root nodes because they must not be removed

--- 
Update version to 0.5

---
**Changes must not be squashed!**