### PR TITLE
Fix #7: Unify class and interface naming to not use "JsonForms" as a prefix

### DIFF
--- a/DOCUMENTATION.MD
+++ b/DOCUMENTATION.MD
@@ -4,7 +4,7 @@ The detail is rendered with JSON Forms.
 # Configuring a tree editor
 To use the tree editor for a custom model, the following classes and interfaces need to be extended resp. implemented.
 
-## JsonFormsTreeEditorWidget
+## BaseTreeEditorWidget
 The implementation of this abstract class is the the whole editor widget containing a tree and a detail
 whose content depends on the node selected in the tree.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "theia-tree-editor",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "license": "(EPL-2.0 OR MIT)",
   "author": {
     "name": "EclipseSource"

--- a/src/browser/detail-form-widget.tsx
+++ b/src/browser/detail-form-widget.tsx
@@ -21,8 +21,11 @@ import { combineReducers, createStore } from 'redux';
 
 import { TreeEditor } from './interfaces';
 
+/**
+ * Renders the detail view of the tree editor and binds the selected object's data to a generated form.
+ */
 @injectable()
-export class JSONFormsWidget extends BaseWidget {
+export class DetailFormWidget extends BaseWidget {
   private selectedNode: TreeEditor.Node;
   private store: any;
 

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -9,10 +9,10 @@
  * SPDX-License-Identifier: EPL-2.0 OR MIT
  ********************************************************************************/
 export * from './interfaces';
-export * from './json-forms-widget';
+export * from './detail-form-widget';
 export * from './tree-editor-contribution';
 export * from './tree-editor-widget';
-export * from './tree-widget';
+export * from './master-tree-widget';
 export * from './util';
 
 export * from './navigatable-tree-editor-widget';

--- a/src/browser/master-tree-widget.tsx
+++ b/src/browser/master-tree-widget.tsx
@@ -28,20 +28,20 @@ export interface AddCommandProperty {
   type: string
 }
 
-export interface JsonFormsTreeAnchor {
+export interface TreeAnchor {
   x: number,
   y: number,
   node: TreeEditor.Node,
   onClick: (property: string, type: string) => void
 }
 
-export namespace JsonFormsTreeContextMenu {
-  export const CONTEXT_MENU: MenuPath = ['json-forms-tree-context-menu'];
-  export const ADD_MENU: MenuPath = ['json-forms-tree-add-menu'];
+export namespace TreeContextMenu {
+  export const CONTEXT_MENU: MenuPath = ['theia-tree-editor-tree-context-menu'];
+  export const ADD_MENU: MenuPath = ['theia-tree-editor-tree-add-menu'];
 }
 
 @injectable()
-export class JsonFormsTreeWidget extends TreeWidget {
+export class MasterTreeWidget extends TreeWidget {
   protected onTreeWidgetSelectionEmitter = new Emitter<
     readonly Readonly<TreeEditor.Node>[]
   >();
@@ -56,14 +56,13 @@ export class JsonFormsTreeWidget extends TreeWidget {
     @inject(TreeEditor.NodeFactory) protected readonly nodeFactory: TreeEditor.NodeFactory
   ) {
     super(props, model, contextMenuRenderer);
-    this.id = JsonFormsTreeWidget.WIDGET_ID;
-    this.title.label = JsonFormsTreeWidget.WIDGET_LABEL;
-    this.title.caption = JsonFormsTreeWidget.WIDGET_LABEL;
-    this.addClass(JsonFormsTreeWidget.Styles.JSONFORMS_TREE_CLASS);
+    this.id = MasterTreeWidget.WIDGET_ID;
+    this.title.label = MasterTreeWidget.WIDGET_LABEL;
+    this.title.caption = MasterTreeWidget.WIDGET_LABEL;
 
     model.root = {
-      id: JsonFormsTreeWidget.WIDGET_ID,
-      name: JsonFormsTreeWidget.WIDGET_LABEL,
+      id: MasterTreeWidget.WIDGET_ID,
+      name: MasterTreeWidget.WIDGET_LABEL,
       parent: undefined,
       visible: false,
       children: []
@@ -73,8 +72,6 @@ export class JsonFormsTreeWidget extends TreeWidget {
   @postConstruct()
   protected init() {
     super.init();
-
-    this.addClass('tree-container');
 
     this.toDispose.push(this.onTreeWidgetSelectionEmitter);
     this.toDispose.push(this.onDeleteEmitter);
@@ -165,14 +162,14 @@ export class JsonFormsTreeWidget extends TreeWidget {
   private createAddHandler(node: TreeEditor.Node): (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void {
     return event => {
       const addHandler = (property: string, type: string) => this.onAddEmitter.fire({ node, property, type });
-      const treeAnchor: JsonFormsTreeAnchor = {
+      const treeAnchor: TreeAnchor = {
         x: event.nativeEvent.x,
         y: event.nativeEvent.y,
         node: node,
         onClick: addHandler
       };
       const renderOptions: RenderContextMenuOptions = {
-        menuPath: JsonFormsTreeContextMenu.ADD_MENU,
+        menuPath: TreeContextMenu.ADD_MENU,
         anchor: treeAnchor,
       };
       this.contextMenuRenderer.render(renderOptions);
@@ -326,14 +323,7 @@ export class JsonFormsTreeWidget extends TreeWidget {
   }
 }
 
-export namespace JsonFormsTreeWidget {
-  export const WIDGET_ID = 'json-forms-tree';
-  export const WIDGET_LABEL = 'JSONForms Tree';
-
-  /**
-   * CSS styles for the `JSONForms Hierarchy` widget.
-   */
-  export namespace Styles {
-    export const JSONFORMS_TREE_CLASS = 'json-forms-tree';
-  }
+export namespace MasterTreeWidget {
+  export const WIDGET_ID = 'theia-tree-editor-tree';
+  export const WIDGET_LABEL = 'Theia Tree Editor - Tree';
 }

--- a/src/browser/navigatable-tree-editor-widget.ts
+++ b/src/browser/navigatable-tree-editor-widget.ts
@@ -13,22 +13,22 @@ import { Navigatable, Title, Widget } from '@theia/core/lib/browser';
 import URI from '@theia/core/lib/common/uri';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
 
-import { JSONFormsWidget } from './json-forms-widget';
-import { JsonFormsTreeEditorWidget } from './tree-editor-widget';
-import { JsonFormsTreeWidget } from './tree-widget';
+import { DetailFormWidget } from './detail-form-widget';
+import { BaseTreeEditorWidget } from './tree-editor-widget';
+import { MasterTreeWidget } from './master-tree-widget';
 
 export const NavigatableTreeEditorOptions = Symbol(
-    'JsonFormsTreeEditorWidgetOptions'
+    'NavigatableTreeEditorOptions'
 );
 export interface NavigatableTreeEditorOptions {
     uri: URI;
 }
 
-export abstract class NavigatableTreeEditorWidget extends JsonFormsTreeEditorWidget implements Navigatable {
+export abstract class NavigatableTreeEditorWidget extends BaseTreeEditorWidget implements Navigatable {
 
     constructor(
-        protected readonly treeWidget: JsonFormsTreeWidget,
-        protected readonly formWidget: JSONFormsWidget,
+        protected readonly treeWidget: MasterTreeWidget,
+        protected readonly formWidget: DetailFormWidget,
         protected readonly workspaceService: WorkspaceService,
         protected readonly logger: ILogger,
         readonly widget_id: string,

--- a/src/browser/resource/resource-tree-editor-widget.ts
+++ b/src/browser/resource/resource-tree-editor-widget.ts
@@ -12,21 +12,21 @@ import { DefaultResourceProvider, Resource } from '@theia/core/lib/common';
 import { ILogger } from '@theia/core/lib/common';
 import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
 import { postConstruct } from 'inversify';
-import { AddCommandProperty, JsonFormsTreeWidget } from '../tree-widget';
+import { AddCommandProperty, MasterTreeWidget } from '../master-tree-widget';
 import { TreeEditor } from '../interfaces';
 import {
   NavigatableTreeEditorWidget,
   NavigatableTreeEditorOptions,
 } from '../navigatable-tree-editor-widget';
-import { JSONFormsWidget } from '../json-forms-widget';
+import { DetailFormWidget } from '../detail-form-widget';
 
 export abstract class ResourceTreeEditorWidget extends NavigatableTreeEditorWidget {
   protected resource: Resource;
   protected data: any;
 
   constructor(
-    protected readonly treeWidget: JsonFormsTreeWidget,
-    protected readonly formWidget: JSONFormsWidget,
+    protected readonly treeWidget: MasterTreeWidget,
+    protected readonly formWidget: DetailFormWidget,
     protected readonly workspaceService: WorkspaceService,
     protected readonly logger: ILogger,
     readonly widget_id: string,

--- a/src/browser/tree-editor-contribution.ts
+++ b/src/browser/tree-editor-contribution.ts
@@ -19,11 +19,17 @@ import {
 import { WidgetOpenHandler, LabelProviderContribution } from '@theia/core/lib/browser';
 
 import { TreeEditor } from './interfaces';
-import { JsonFormsTreeEditorWidget } from './tree-editor-widget';
-import { JsonFormsTreeAnchor, JsonFormsTreeContextMenu } from './tree-widget';
+import { BaseTreeEditorWidget } from './tree-editor-widget';
+import { TreeAnchor, TreeContextMenu } from './master-tree-widget';
 import { generateAddCommands } from './util';
 
-export abstract class JsonFormsTreeEditorContribution extends WidgetOpenHandler<JsonFormsTreeEditorWidget> implements CommandContribution, MenuContribution {
+/**
+ * Abstract base class for defining custom tree editor contributions.
+ * An editor's contribution registers its commands and context menus.
+ * Furthermore, it defines which URIs the editor can handle and may configure
+ * the widget with additional options (see WidgetOpenHandler).
+ */
+export abstract class BaseTreeEditorContribution extends WidgetOpenHandler<BaseTreeEditorWidget> implements CommandContribution, MenuContribution {
     private commandMap: Map<string, Map<string, Command>>;
 
     constructor(
@@ -55,7 +61,7 @@ export abstract class JsonFormsTreeEditorContribution extends WidgetOpenHandler<
                     editorId: this.editorId,
                     type
                 };
-                menus.registerMenuAction(JsonFormsTreeContextMenu.ADD_MENU, {
+                menus.registerMenuAction(TreeContextMenu.ADD_MENU, {
                     commandId: command.id,
                     label: command.label,
                     icon: this.labelProvider.getIcon(iconInfo)
@@ -73,11 +79,11 @@ class AddCommandHandler implements CommandHandler {
         private modelService: TreeEditor.ModelService) {
     }
 
-    execute(treeAnchor: JsonFormsTreeAnchor) {
+    execute(treeAnchor: TreeAnchor) {
         treeAnchor.onClick(this.property, this.type);
     }
 
-    isVisible(treeAnchor: JsonFormsTreeAnchor): boolean {
+    isVisible(treeAnchor: TreeAnchor): boolean {
         if (!treeAnchor) {
             return false;
         }

--- a/src/browser/tree-editor-widget.tsx
+++ b/src/browser/tree-editor-widget.tsx
@@ -18,12 +18,11 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 
 import { TreeEditor } from './interfaces';
-import { JSONFormsWidget } from './json-forms-widget';
-import { AddCommandProperty, JsonFormsTreeWidget } from './tree-widget';
+import { DetailFormWidget } from './detail-form-widget';
+import { AddCommandProperty, MasterTreeWidget } from './master-tree-widget';
 
 @injectable()
-export abstract class JsonFormsTreeEditorWidget extends BaseWidget
-  implements Saveable {
+export abstract class BaseTreeEditorWidget extends BaseWidget implements Saveable {
   public dirty: boolean = false;
   public autoSave: 'off';
   private splitPanel: SplitPanel;
@@ -38,8 +37,8 @@ export abstract class JsonFormsTreeEditorWidget extends BaseWidget
   protected instanceData: any;
 
   constructor(
-    protected readonly treeWidget: JsonFormsTreeWidget,
-    protected readonly formWidget: JSONFormsWidget,
+    protected readonly treeWidget: MasterTreeWidget,
+    protected readonly formWidget: DetailFormWidget,
     protected readonly workspaceService: WorkspaceService,
     protected readonly logger: ILogger,
     readonly widget_id: string
@@ -47,10 +46,10 @@ export abstract class JsonFormsTreeEditorWidget extends BaseWidget
     super();
     this.id = widget_id;
     this.splitPanel = new SplitPanel();
-    this.addClass('json-forms-tree-editor');
-    this.splitPanel.addClass('json-forms-tree-editor-sash');
-    this.treeWidget.addClass('json-forms-tree-editor-tree');
-    this.formWidget.addClass('json-forms-tree-editor-forms');
+    this.addClass(BaseTreeEditorWidget.Styles.EDITOR);
+    this.splitPanel.addClass(BaseTreeEditorWidget.Styles.SASH);
+    this.treeWidget.addClass(BaseTreeEditorWidget.Styles.TREE);
+    this.formWidget.addClass(BaseTreeEditorWidget.Styles.FORM);
     this.formWidget.onChange(
       debounce(data => {
         if (
@@ -177,10 +176,13 @@ export abstract class JsonFormsTreeEditorWidget extends BaseWidget
   protected abstract configureTitle(title: Title<Widget>): void;
 }
 
-export namespace JsonFormsTreeEditorWidget {
-  export const WIDGET_LABEL = 'JSONForms Tree Editor';
+export namespace BaseTreeEditorWidget {
+  export const WIDGET_LABEL = 'Theia Tree Editor';
 
   export namespace Styles {
-    export const JSONFORMS_TREE_EDITOR_CLASS = 'json-forms-tree-editor';
+    export const EDITOR = 'theia-tree-editor';
+    export const TREE = 'theia-tree-editor-tree';
+    export const FORM = 'theia-tree-editor-form';
+    export const SASH = 'theia-tree-editor-sash';
   }
 }

--- a/src/browser/util.ts
+++ b/src/browser/util.ts
@@ -9,30 +9,30 @@
  * SPDX-License-Identifier: EPL-2.0 OR MIT
  ********************************************************************************/
 import { Command } from '@theia/core';
-import { createTreeContainer, defaultTreeProps, TreeProps, TreeWidget } from '@theia/core/lib/browser/tree';
+import { createTreeContainer, defaultTreeProps, TreeProps, TreeWidget as TheiaTreeWidget} from '@theia/core/lib/browser/tree';
 import { interfaces } from 'inversify';
 
 import { TreeEditor } from './interfaces';
-import { JSONFormsWidget } from './json-forms-widget';
-import { JsonFormsTreeEditorWidget } from './tree-editor-widget';
-import { JsonFormsTreeContextMenu, JsonFormsTreeWidget } from './tree-widget';
+import { DetailFormWidget } from './detail-form-widget';
+import { BaseTreeEditorWidget } from './tree-editor-widget';
+import { TreeContextMenu, MasterTreeWidget } from './master-tree-widget';
 
-export const JSON_FORMS_TREE_PROPS = <TreeProps>{
+export const TREE_PROPS = <TreeProps>{
     ...defaultTreeProps,
-    contextMenuPath: JsonFormsTreeContextMenu.CONTEXT_MENU,
+    contextMenuPath: TreeContextMenu.CONTEXT_MENU,
     multiSelect: false,
     search: false
 };
 
-function createJsonFormsTreeWidget(
+function createTreeWidget(
     parent: interfaces.Container
-): JsonFormsTreeWidget {
+): MasterTreeWidget {
     const treeContainer = createTreeContainer(parent);
 
-    treeContainer.unbind(TreeWidget);
-    treeContainer.bind(JsonFormsTreeWidget).toSelf();
-    treeContainer.rebind(TreeProps).toConstantValue(JSON_FORMS_TREE_PROPS);
-    return treeContainer.get(JsonFormsTreeWidget);
+    treeContainer.unbind(TheiaTreeWidget);
+    treeContainer.bind(MasterTreeWidget).toSelf();
+    treeContainer.rebind(TreeProps).toConstantValue(TREE_PROPS);
+    return treeContainer.get(MasterTreeWidget);
 }
 
 /**
@@ -49,16 +49,15 @@ function createJsonFormsTreeWidget(
  */
 export function createBasicTreeContainter(
     parent: interfaces.Container,
-    treeEditorWidget: interfaces.Newable<JsonFormsTreeEditorWidget>,
+    treeEditorWidget: interfaces.Newable<BaseTreeEditorWidget>,
     modelService: interfaces.Newable<TreeEditor.ModelService>,
     nodeFactory: interfaces.Newable<TreeEditor.NodeFactory>): interfaces.Container {
 
     const container = parent.createChild();
     container.bind(TreeEditor.ModelService).to(modelService);
     container.bind(TreeEditor.NodeFactory).to(nodeFactory);
-    container.bind(JSONFormsWidget).toSelf();
-    container.bind(JsonFormsTreeWidget).toDynamicValue(context =>
-        createJsonFormsTreeWidget(context.container));
+    container.bind(DetailFormWidget).toSelf();
+    container.bind(MasterTreeWidget).toDynamicValue(context => createTreeWidget(context.container));
     container.bind(treeEditorWidget).toSelf();
 
     return container;

--- a/style/index.css
+++ b/style/index.css
@@ -16,63 +16,63 @@ button[type="button"] {
   padding: 0;
 }
 
-.json-forms-tree-editor, .json-forms-tree-editor-sash, .json-forms-tree-editor-tree, .json-forms-tree-editor-forms {
+.theia-tree-editor, .theia-tree-editor-sash, .theia-tree-editor-tree, .theia-tree-editor-form {
   height: 100%;
 }
 
-.json-forms-tree-editor, .json-forms-tree-editor-sash {
+.theia-tree-editor, .theia-tree-editor-sash {
   width: 100%;
 }
 
-.json-forms-tree-editor-tree, .json-forms-tree-editor-forms {
+.theia-tree-editor-tree, .theia-tree-editor-form {
   overflow-y: auto;
 }
 
-.json-forms-tree-editor-tree {
+.theia-tree-editor-tree {
   min-width: 250px;
 }
 
-.json-forms-tree-editor-tree .tree-icon-container {
+.theia-tree-editor-tree .tree-icon-container {
   width: 16px;
   margin-right: 5px;
   text-align: center;
 }
 
-.json-forms-tree .node-buttons {
+.theia-tree-editor-tree .node-buttons {
   visibility: hidden;
 }
 
-.json-forms-tree .node-button {
+.theia-tree-editor-tree .node-button {
   margin-left: 5px;
 }
 
-.json-forms-tree .theia-TreeNode:hover .node-buttons {
+.theia-tree-editor-tree .theia-TreeNode:hover .node-buttons {
   visibility: inherit;
 }
 
 /* Theia-specific styling */
 
-.json-forms-tree-editor .control {
+.theia-tree-editor .control {
   display: flex;
   flex-direction: column;
   margin: 2em;
 }
 
-.json-forms-tree-editor .control > label {
+.theia-tree-editor .control > label {
   color: var(--theia-ui-font-color0);
   font-size: var(--theia-ui-font-size2);
   order: -1;
   font-weight: bold;
 }
 
-.json-forms-tree-editor .control > .validation {
+.theia-tree-editor .control > .validation {
   order: -1;
 }
 
-.json-forms-tree-editor .control > .input-description {
+.theia-tree-editor .control > .input-description {
   color: var(--theia-content-font-color0);
 }
 
-.json-forms-tree-editor .control > .validation_error {
+.theia-tree-editor .control > .validation_error {
   color: var(--theia-error-color0);
 }


### PR DESCRIPTION
* Rename JsonFormsTreeWidget to MasterTreeWidget
* Rename tree props and internal function in util.ts
* JsonFormsTreeAnchor -> TreeAnchor
* JsonFormsTreeContextMenu -> TreeContextMenu
* Adapt the context menu path constants
* JsonFormsTreeEditorContribution -> BaseTreeEditorContribution
* JSONFormsWidget -> DetailFormWidget
* Rename css classes to use prefix 'theia-tree-editor'
* Remove unnecessary css class assignments in the tree widget
* Increase version to 0.6